### PR TITLE
pytest-celery 1.2.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,10 +49,6 @@ test:
     - pytest_celery.vendors
   requires:
     - pip
-    - pytest
-    - psutil
-    - pytest-docker-tools
-    - celery
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # pytest-celery 1.2.1 unresolved on py3.13 due to docker-py<8 & urllib3<2
-  skip: true  # [py<=3.8 or py>=3.13]
+  skip: true  # [py<=3.8]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -38,7 +38,7 @@ requirements:
     #-- sqs
     - boto3 *
     - botocore *
-    - urllib3 >=1.26.16,<2.0
+    - urllib3 >=1.26.16
     #--
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
     sha256: 7873fb3cf4fbfe9b0dd15d359bdb8bbab4a41c7e48f5b0adb7d36138d3704d52
 
-    # tests and tests data files
+    # tests from github source
   - url: https://github.com/celery/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
     sha256: 1fda701c4683ba8fa5d404794b0dd141c95478ed71e9abe0d38da3f60d74ea49
     folder: gh_src
@@ -74,7 +74,6 @@ test:
 
 about:
   home: https://github.com/celery/pytest-celery
-  summary: Pytest plugin for Celery
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: Other

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  # pytest-celery 1.2.1 unresolved on py3.13 due to docker-py<8 & urllib3<2
   skip: true  # [py<=3.8]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
@@ -38,7 +37,6 @@ requirements:
     #-- sqs
     - boto3 *
     - botocore *
-    - urllib3 >=1.26.16
     #--
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   host:
     - python
     - poetry-core >=1.8.1
-    - celery
     - pip
   run:
     - python
@@ -77,7 +76,7 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE
   license_family: Other
-  summary: A library for property based testing
+  summary: Pytest plugin for Celery
   description: |
      It is pytest plugin designed for Celery application developers.
      It enables dynamic orchestration of Celery environments for testing tasks

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,10 @@ test:
     - pytest_celery.vendors
   requires:
     - pip
-    - psutil >=7.0.0
+    - pytest
+    - psutil
+    - pytest-docker-tools
+    - celery
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<=3.8]
+  # pytest-celery 1.2.1 unresolved on py3.13 due to docker-py<8 & urllib3<2
+  skip: true  # [py<=3.8 or py>=3.13]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,17 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pytest_celery-{{ version }}.tar.gz
-  sha256: 7873fb3cf4fbfe9b0dd15d359bdb8bbab4a41c7e48f5b0adb7d36138d3704d52
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+    sha256: 7873fb3cf4fbfe9b0dd15d359bdb8bbab4a41c7e48f5b0adb7d36138d3704d52
+
+    # tests and tests data files
+  - url: https://github.com/celery/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 1fda701c4683ba8fa5d404794b0dd141c95478ed71e9abe0d38da3f60d74ea49
+    folder: gh_src
 
 build:
   number: 0
-  skip: true  # [py<=3.8]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -40,6 +45,8 @@ requirements:
     #--
 
 test:
+  source_files:
+    - gh_src/tests
   imports:
     - pytest_celery
     - pytest_celery.api
@@ -48,9 +55,22 @@ test:
     - pytest_celery.vendors
   requires:
     - pip
+    - pytest
+    - redis-py
+    - python-memcached
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - >
+      python -c "open('pytest.ini','w').write(
+      '[pytest]\n'
+      'pythonpath = gh_src\n'
+      'python_classes = test*\n'
+      'python_files = test_*.py\n'
+      'python_functions = test_*\n'
+      'testpaths = gh_src/tests/unit\n'
+      )"
+    - python -m pytest -ra -vv
 
 about:
   home: https://github.com/celery/pytest-celery

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ test:
     - pytest_celery.vendors
   requires:
     - pip
+    - psutil >=7.0.0
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,42 +1,71 @@
 {% set name = "pytest-celery" %}
-{% set version = "0.0.0a1" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-celery-{{ version }}.tar.gz
-  sha256: 3e0e0817c2d3f2870dafebd915bf13100fc12920b5d42dfe5fdc35844fe42e62
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pytest_celery-{{ version }}.tar.gz
+  sha256: 7873fb3cf4fbfe9b0dd15d359bdb8bbab4a41c7e48f5b0adb7d36138d3704d52
 
 build:
-  number: 1
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: true  # [py<=3.8]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
-    - pip
-    - flit
     - python
+    - poetry-core >=1.8.1
+    - celery
+    - pip
   run:
-    - pytest
+    - python
+    - celery
+    - kombu
+    - tenacity >=9.0.0
+    - pytest-docker-tools >=3.1.3
+    - docker-py >=7.1.0,<8.0.0
+    - psutil >=7.0.0
+    - setuptools >=60.0.0,<75.0.0  # [py>=38 and py<39]
+    - setuptools >=75.8.0  # [py>=39 and py<4]
+    - debugpy >=1.8.12,<2.0.0
+  run_constrained:
+    - redis-py *
+    - python-memcached *
+    #-- sqs
+    - boto3 *
+    - botocore *
+    - urllib3 >=1.26.16,<2.0
+    #--
 
 test:
   imports:
     - pytest_celery
-  commands:
-    - pip check
-    - "pytest --fixtures | grep 'plugins: celery'"
+    - pytest_celery.api
+    - pytest_celery.defaults
+    - pytest_celery.fixtures
+    - pytest_celery.vendors
   requires:
     - pip
-    - celery >=4.4.0
-    
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+
 about:
-  home: https://github.com/graingert/pytest-celery
-  summary: pytest-celery a shim pytest plugin to enable celery.contrib.pytest
+  home: https://github.com/celery/pytest-celery
+  summary: Pytest plugin for Celery
   license: BSD-3-Clause
   license_file: LICENSE
+  license_family: Other
+  summary: A library for property based testing
+  description: |
+     It is pytest plugin designed for Celery application developers.
+     It enables dynamic orchestration of Celery environments for testing tasks
+     in isolated conditions, leveraging Docker & pytest-docker-tools for environment simulation.
+  dev_url: https://github.com/celery/pytest-celery
+  doc_url: https://docs.celeryq.dev/projects/pytest-celery
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
pytest-celery 1.2.1 

**Destination channel:** None

### Links

- [PKG-9162]
- dev_url:        https://github.com/graingert/pytest-celery/tree/v1.2.1
- conda_forge:    https://github.com/conda-forge/pytest-celery-feedstock
- pypi:           https://pypi.org/project/pytest-celery/1.2.1
- pypi inspector: https://inspector.pypi.io/project/pytest-celery/1.2.1

### Explanation of changes:

- new version number


[PKG-9162]: https://anaconda.atlassian.net/browse/PKG-9162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ