### PR TITLE
pytest-celery 1.3.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ requirements:
     - boto3 *
     - botocore *
     #--
-    - pycurl >=7.43  # [unix]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,23 @@
 {% set name = "pytest-celery" %}
-{% set version = "1.2.1" %}
+{% set version = "1.3.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
-    sha256: 7873fb3cf4fbfe9b0dd15d359bdb8bbab4a41c7e48f5b0adb7d36138d3704d52
+    sha256: bd9e5b0f594ec5de9ab97cf27e3a11c644718a761bab6b997d01800fd7394f64
 
     # tests from github source
   - url: https://github.com/celery/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 1fda701c4683ba8fa5d404794b0dd141c95478ed71e9abe0d38da3f60d74ea49
+    sha256: b2d797fd5fe557fc070509683ca8caa06c5bca6eafb4367d96496f0f84db0f04
     folder: gh_src
 
 build:
   number: 0
-  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: true  # [py<38]
 
 requirements:
   host:
@@ -32,8 +32,6 @@ requirements:
     - pytest-docker-tools >=3.1.3
     - docker-py >=7.1.0,<8.0.0
     - psutil >=7.0.0
-    - setuptools >=60.0.0,<75.0.0  # [py>=38 and py<39]
-    - setuptools >=75.8.0  # [py>=39 and py<4]
     - debugpy >=1.8.12,<2.0.0
   run_constrained:
     - redis-py *
@@ -42,6 +40,8 @@ requirements:
     - boto3 *
     - botocore *
     #--
+    - pycurl >=7.43  # [unix]
+    - urllib3 >=1.26.16,<2.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,6 @@ package:
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
     sha256: bd9e5b0f594ec5de9ab97cf27e3a11c644718a761bab6b997d01800fd7394f64
-
     # tests from github source
   - url: https://github.com/celery/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
     sha256: b2d797fd5fe557fc070509683ca8caa06c5bca6eafb4367d96496f0f84db0f04
@@ -41,7 +40,6 @@ requirements:
     - botocore *
     #--
     - pycurl >=7.43  # [unix]
-    - urllib3 >=1.26.16,<2.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,7 @@ about:
   license_family: Other
   summary: Pytest plugin for Celery
   description: |
-     It is pytest plugin designed for Celery application developers.
+     It is a pytest plugin designed for Celery application developers.
      It enables dynamic orchestration of Celery environments for testing tasks
      in isolated conditions, leveraging Docker & pytest-docker-tools for environment simulation.
   dev_url: https://github.com/celery/pytest-celery


### PR DESCRIPTION
pytest-celery 1.3.0 

**Destination channel:** Defaults

### Links

- [PKG-15325]
- dev_url:        https://github.com/celery/pytest-celery/tree/v1.3.0
- conda_forge:    https://github.com/conda-forge/pytest-celery-feedstock
- pypi:           https://pypi.org/project/pytest-celery/1.3.0
- pypi inspector: https://inspector.pypi.io/project/pytest-celery/1.3.0

### Explanation of changes:

- new version number


[PKG-15325]: https://anaconda.atlassian.net/browse/PKG-15325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ